### PR TITLE
Cria página para listagem de Associações, com a opção de editar a associação também

### DIFF
--- a/src/app/_pipes/cpfcnpj.pipe.spec.ts
+++ b/src/app/_pipes/cpfcnpj.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { CpfcnpjPipe } from './cpfcnpj.pipe';
+
+describe('CpfcnpjPipe', () => {
+  it('create an instance', () => {
+    const pipe = new CpfcnpjPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/_pipes/cpfcnpj.pipe.ts
+++ b/src/app/_pipes/cpfcnpj.pipe.ts
@@ -1,0 +1,17 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'cpfcnpj'
+})
+export class CpfcnpjPipe implements PipeTransform {
+
+  transform(value: string, ...args: any[]): any {
+    if (value.length === 11) {
+      return value.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/g, '\$1.\$2.\$3\-\$4');
+    }
+    if (value.length === 14) {
+      return value.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/g, '\$1.\$2.\$3\/\$4\-\$5');
+    }
+    return 'error';
+  }
+}

--- a/src/app/_pipes/cpfcnpj.pipe.ts
+++ b/src/app/_pipes/cpfcnpj.pipe.ts
@@ -5,13 +5,13 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class CpfcnpjPipe implements PipeTransform {
 
-  transform(value: string, ...args: any[]): any {
+  transform(value: string): string {
     if (value.length === 11) {
       return value.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/g, '\$1.\$2.\$3\-\$4');
     }
     if (value.length === 14) {
       return value.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/g, '\$1.\$2.\$3\/\$4\-\$5');
     }
-    return 'error';
+    return value;
   }
 }

--- a/src/app/_services/associacao.service.ts
+++ b/src/app/_services/associacao.service.ts
@@ -10,6 +10,7 @@ import { Observable, throwError } from 'rxjs';
 export class AssociacaoService {
 
   associacao: Associacao = new Associacao();
+  associacoes: Array<Associacao> = []
 
   constructor(private httpClient: HttpClient) { }
 
@@ -23,6 +24,14 @@ export class AssociacaoService {
 
   getAssociacaoPorCnpj(cnpj: string): Observable<any> {
     return this.httpClient.get<any>('http://localhost:8080/associacao/cnpj/' + cnpj);
+  }
+
+  listarAssociacao(): Observable<any>{
+    return this.httpClient.get<Associacao[]>('http://localhost:8080/associacao');
+  }
+
+  zerarAssociacao(){
+    this.associacao = new Associacao();
   }
 
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,6 +6,7 @@ import { CadastrarCriadorComponent } from './paginas/cadastrar-criador/cadastrar
 import { ComprovanteCadastroCriadorComponent } from './paginas/comprovante-cadastro-criador/comprovante-cadastro-criador.component';
 import { CadastrarAssociacaoComponent } from './paginas/cadastrar-associacao/cadastrar-associacao.component';
 import { ComprovanteCadastroAssociacaoComponent } from './paginas/comprovante-cadastro-associacao/comprovante-cadastro-associacao.component';
+import { ListarAssociacaoComponent } from './paginas/listar-associacao/listar-associacao.component'
 
 const routes: Routes = [
   { path: '', component: HomeComponent },
@@ -15,6 +16,7 @@ const routes: Routes = [
   { path: 'criador/comprovante-cadastro', component: ComprovanteCadastroCriadorComponent },
   { path: 'associacao/cadastro', component: CadastrarAssociacaoComponent },
   { path: 'associacao/comprovante-cadastro', component: ComprovanteCadastroAssociacaoComponent },
+  { path: 'associacao/listar', component: ListarAssociacaoComponent },
 ];
 
 @NgModule({

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,8 +10,6 @@ export class AppComponent implements OnInit {
   constructor(private router: Router){ }
 
   ngOnInit(): void{
-    console.log('INICIO');
-    // this.router.navigate(["home"]);
   }
 
   vai(){

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,8 +13,10 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatSelectModule } from '@angular/material/select';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-import {MatDialogModule} from '@angular/material/dialog';
-import {MatCardModule} from '@angular/material/card';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatCardModule } from '@angular/material/card';
+import { MatTableModule } from '@angular/material/table';
+import {MatPaginatorModule} from '@angular/material/paginator';
 
 import { NgxMaskModule } from 'ngx-mask'
 
@@ -30,6 +32,8 @@ import { ComprovanteCadastroCriadorComponent } from './paginas/comprovante-cadas
 import { TermoDeResponsabilidadeComponent } from './modals/termo-de-responsabilidade/termo-de-responsabilidade.component';
 import { CadastrarAssociacaoComponent } from './paginas/cadastrar-associacao/cadastrar-associacao.component';
 import { ComprovanteCadastroAssociacaoComponent } from './paginas/comprovante-cadastro-associacao/comprovante-cadastro-associacao.component';
+import { ListarAssociacaoComponent } from './paginas/listar-associacao/listar-associacao.component';
+import { CpfcnpjPipe } from './_pipes/cpfcnpj.pipe';
 
 @NgModule({
   declarations: [
@@ -42,7 +46,10 @@ import { ComprovanteCadastroAssociacaoComponent } from './paginas/comprovante-ca
     ComprovanteCadastroCriadorComponent,
     TermoDeResponsabilidadeComponent,
     CadastrarAssociacaoComponent,
-    ComprovanteCadastroAssociacaoComponent
+    ComprovanteCadastroAssociacaoComponent,
+    ListarAssociacaoComponent,
+    CpfcnpjPipe
+    
   ],
   imports: [
     BrowserModule,
@@ -63,6 +70,8 @@ import { ComprovanteCadastroAssociacaoComponent } from './paginas/comprovante-ca
     MatSnackBarModule,
     MatDialogModule,
     MatCardModule,
+    MatTableModule,
+    MatPaginatorModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/paginas/cadastrar-associacao/cadastrar-associacao.component.html
+++ b/src/app/paginas/cadastrar-associacao/cadastrar-associacao.component.html
@@ -11,7 +11,7 @@
                         <p>
                             <mat-form-field appearance="outline">
                                 <mat-label>Nome</mat-label>
-                                <input matInput placeholder="" formControlName="nomeFormControl" minlength="2" required>
+                                <input matInput formControlName="nomeFormControl" minlength="2" required>
                                 <mat-error *ngIf="formCadastro.controls.nomeFormControl.errors?.minlength">Tem que
                                     ter no mínimo 2 caracteres</mat-error>
                                 <mat-error *ngIf="formCadastro.controls.nomeFormControl.errors?.required">Campo
@@ -24,8 +24,7 @@
                         <p>
                             <mat-form-field appearance="outline">
                                 <mat-label>Sigla</mat-label>
-                                <input matInput placeholder="" formControlName="siglaFormControl" minlength="2"
-                                    required>
+                                <input matInput formControlName="siglaFormControl" minlength="2" required>
                                 <mat-error *ngIf="formCadastro.controls.siglaFormControl.errors?.minlength">Tem que
                                     ter no mínimo 2 caracteres</mat-error>
                                 <mat-error *ngIf="formCadastro.controls.siglaFormControl.errors?.required">Campo
@@ -60,8 +59,8 @@
                         <p>
                             <mat-form-field appearance="outline">
                                 <mat-label>Cidade</mat-label>
-                                <input matInput placeholder="" formControlName="cidadeFormControl" minlength="3"
-                                    maxlength="100" required>
+                                <input matInput formControlName="cidadeFormControl" minlength="3" maxlength="100"
+                                    required>
                                 <mat-error *ngIf="formCadastro.controls.cidadeFormControl.errors?.required">Campo
                                     obrigatório</mat-error>
                                 <mat-error *ngIf="formCadastro.controls.cidadeFormControl.errors?.minlength">Tem que
@@ -92,10 +91,12 @@
 
                 <mat-divider></mat-divider>
 
-                <div class="box2">
+                <div class="box5">
                     <button mat-raised-button class="botaoCadastrar" type="submit"
                         [disabled]="formCadastro.invalid">Concluir
                         cadastro</button>
+                    <button mat-raised-button class="botaoCadastrar"
+                        (click)="goToPage('associacao/listar')">Cancelar</button>
                 </div>
             </form>
         </div>

--- a/src/app/paginas/cadastrar-associacao/cadastrar-associacao.component.scss
+++ b/src/app/paginas/cadastrar-associacao/cadastrar-associacao.component.scss
@@ -38,6 +38,17 @@
   .box4 {
       width: 49%;
   }
+
+  .box5 {
+    width: 100%;
+    height: max-content;
+    margin: 15px 0 15px 0;
+    background: #fff;
+    flex-direction: row;
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
   
   h1 {
     color: #795548;
@@ -82,6 +93,7 @@
   
   .botaoCadastrar {
     background-color: #8BC34A;
+    margin-right: 15px;
   }
   
   form {

--- a/src/app/paginas/cadastrar-associacao/cadastrar-associacao.component.ts
+++ b/src/app/paginas/cadastrar-associacao/cadastrar-associacao.component.ts
@@ -34,21 +34,22 @@ export class CadastrarAssociacaoComponent implements OnInit {
 
   forbiddenNameValidator(nameRe: Associacao): ValidatorFn {
     return (control: AbstractControl): { [key: string]: any } | null => {
-      console.log('forbiddenNameValidator', nameRe)
       const forbidden = nameRe;
       return forbidden.cnpj === control.value ? { forbiddenName: { value: control.value } } : null;
     };
   }
 
   formCadastro = new FormGroup({
-    cnpjFormControl: new FormControl('01332547000101'),
-    siglaFormControl: new FormControl('ABC'),
-    nomeFormControl: new FormControl('Pardal Torneios'),
-    cidadeFormControl: new FormControl('Joaquim Távora'),
-    ufFormControl: new FormControl('PR')
+    cnpjFormControl: new FormControl(this.associacaoService.associacao.cnpj ? this.associacaoService.associacao.cnpj : ''),
+    siglaFormControl: new FormControl(this.associacaoService.associacao.sigla ? this.associacaoService.associacao.sigla : ''),
+    nomeFormControl: new FormControl(this.associacaoService.associacao.nome ? this.associacaoService.associacao.nome : ''),
+    cidadeFormControl: new FormControl(this.associacaoService.associacao.cidade ? this.associacaoService.associacao.cidade : ''),
+    ufFormControl: new FormControl(this.associacaoService.associacao.uf ? this.associacaoService.associacao.uf : ''),
+    idFormControl: new FormControl(this.associacaoService.associacao.id ? this.associacaoService.associacao.id : '')
   });
 
   ngOnInit(): void {
+    
   }
 
   onSubmit() {
@@ -57,7 +58,8 @@ export class CadastrarAssociacaoComponent implements OnInit {
       nomeFormControl,
       siglaFormControl,
       cidadeFormControl,
-      ufFormControl
+      ufFormControl,
+      idFormControl
     } = this.formCadastro.controls
 
     this.associacao.cnpj = cnpjFormControl.value;
@@ -65,6 +67,7 @@ export class CadastrarAssociacaoComponent implements OnInit {
     this.associacao.sigla = siglaFormControl.value;
     this.associacao.cidade = cidadeFormControl.value;
     this.associacao.uf = ufFormControl.value;
+    this.associacao.id = idFormControl.value;
 
     if (this.consultaCnpj === this.associacao.cnpj) {
       this.openSnackBar('Este CNPJ já está sendo usando', 'OK');

--- a/src/app/paginas/comprovante-cadastro-associacao/comprovante-cadastro-associacao.component.html
+++ b/src/app/paginas/comprovante-cadastro-associacao/comprovante-cadastro-associacao.component.html
@@ -13,6 +13,7 @@
 
             <div class="box3">
                 <button mat-raised-button (click)="goToPage('home')" class="botaoPaginaInicial">Página Inicial</button>
+                <button mat-raised-button (click)="goToPage('associacao/listar')" class="botaoPaginaInicial">Listar Associações</button>
             </div>
         </div>
     </div>

--- a/src/app/paginas/comprovante-cadastro-associacao/comprovante-cadastro-associacao.component.scss
+++ b/src/app/paginas/comprovante-cadastro-associacao/comprovante-cadastro-associacao.component.scss
@@ -1,69 +1,68 @@
 .container {
-    width: 100%;
-    min-height: 70vh;
-    height: max-content;
-    background: #e8eaeb;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-  }
-  
-  .box {
-    width: 95%;
-    min-height: 60vh;
-    background: #fff;
-    flex-direction: column;
-    display: flex;
-    align-items: center;
-  }
-  
-  .box2 {
-    width: 95%;
-    height: 90%;
-    margin: 15px 0 15px 0;
-    background: #fff;
-    flex-direction: column;
-    display: flex;
-    align-items: flex-start;
-  }
-  
-  .box3 {
-    padding-top: 10px;
-    width: 100%;
-    height: max-content;
-    background: #fff;
-    flex-direction: column;
-    display: flex;
-    align-items: center;
-  //   justify-content: space-between;
-  }
+  width: 100%;
+  min-height: 70vh;
+  height: max-content;
+  background: #e8eaeb;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
 
-  .box4 {
-    width: 40%;
-    height: max-content;
-    flex-direction: column;
-    display: flex;
-    align-items: flex-start;
-  }
-  
-  p {
-    color: #795548;
-    font-size: 16px;
-  }
-  
-  h3 {
-    color: #8bc34a;
-    font-size: 30px;
-    margin: 20px 0 10px;
-    font-weight: 400;
-  }
-  
-  button {
-    background-color: #8bc34a;
-    width: 120px;
-  }
-  
-  .botaoPaginaInicial {
-      margin-left: 10px;
-  }
-  
+.box {
+  width: 95%;
+  min-height: 60vh;
+  background: #fff;
+  flex-direction: column;
+  display: flex;
+  align-items: center;
+}
+
+.box2 {
+  width: 95%;
+  height: 90%;
+  margin: 15px 0 15px 0;
+  background: #fff;
+  flex-direction: column;
+  display: flex;
+  align-items: flex-start;
+}
+
+.box3 {
+  padding-top: 10px;
+  width: 100%;
+  height: max-content;
+  background: #fff;
+  flex-direction: row;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.box4 {
+  width: 40%;
+  height: max-content;
+  flex-direction: column;
+  display: flex;
+  align-items: flex-start;
+}
+
+p {
+  color: #795548;
+  font-size: 16px;
+}
+
+h3 {
+  color: #8bc34a;
+  font-size: 30px;
+  margin: 20px 0 10px;
+  font-weight: 400;
+}
+
+button {
+  background-color: #8bc34a;
+  width: 150px;
+}
+
+.botaoPaginaInicial {
+  margin-left: 10px;
+}

--- a/src/app/paginas/comprovante-cadastro-criador/comprovante-cadastro-criador.component.html
+++ b/src/app/paginas/comprovante-cadastro-criador/comprovante-cadastro-criador.component.html
@@ -1,4 +1,3 @@
-<app-toolbar-principal></app-toolbar-principal>
 <div class="container">
     <div class="box">
         <div class="box2">
@@ -10,5 +9,3 @@
         </div>
     </div>
 </div>
-<app-rodape></app-rodape>
-<router-outlet></router-outlet>

--- a/src/app/paginas/home/home.component.ts
+++ b/src/app/paginas/home/home.component.ts
@@ -16,7 +16,6 @@ export class HomeComponent implements OnInit {
 
   ngOnInit() {
     this.torneioService.getTorneios().subscribe(res => {
-      console.log(res);
     });
   }
 

--- a/src/app/paginas/listar-associacao/listar-associacao.component.html
+++ b/src/app/paginas/listar-associacao/listar-associacao.component.html
@@ -1,0 +1,69 @@
+<div class="container">
+    <div class="box">
+        <div class="box3">
+            <h1>Associações</h1>
+        </div>
+        <div class="box2">
+            <button mat-raised-button (click)="goToPage('associacao/cadastro')">Nova 
+                Associação</button>
+            <mat-form-field>
+                <mat-label>Fitro</mat-label>
+                <input matInput (keyup)="applyFilter($event)" placeholder="Ex. Associação..." #input>
+            </mat-form-field>
+        </div>
+
+        <div class="mat-elevation-z8">
+            <table mat-table [dataSource]="dataSource" matSort>
+
+                <!-- ID Column -->
+                <ng-container matColumnDef="sigla">
+                    <th mat-header-cell *matHeaderCellDef mat-sort-header> Sigla </th>
+                    <td mat-cell *matCellDef="let associacao"> {{associacao.sigla}} </td>
+                </ng-container>
+
+                <!-- Progress Column -->
+                <ng-container matColumnDef="nome">
+                    <th mat-header-cell *matHeaderCellDef mat-sort-header> Nome </th>
+                    <td mat-cell *matCellDef="let associacao"> {{associacao.nome}} </td>
+                </ng-container>
+
+                <!-- Name Column -->
+                <ng-container matColumnDef="cnpj">
+                    <th mat-header-cell *matHeaderCellDef mat-sort-header> CNPJ </th>
+                    <td mat-cell *matCellDef="let associacao"> {{associacao.cnpj | cpfcnpj}} </td>
+                </ng-container>
+
+                <!-- Color Column -->
+                <ng-container matColumnDef="cidade">
+                    <th mat-header-cell *matHeaderCellDef mat-sort-header> Cidade </th>
+                    <td mat-cell *matCellDef="let associacao"> {{associacao.cidade}} </td>
+                </ng-container>
+
+                <ng-container matColumnDef="uf">
+                    <th mat-header-cell *matHeaderCellDef mat-sort-header> UF </th>
+                    <td mat-cell *matCellDef="let associacao"> {{associacao.uf}} </td>
+                </ng-container>
+
+                <ng-container matColumnDef="acoes">
+                    <th mat-header-cell *matHeaderCellDef>Ações</th>
+                    <td mat-cell *matCellDef="let associacao">
+                        <button mat-button>
+                            <mat-icon aria-hidden="false" aria-label="Ícone de lápis"
+                                (click)="editarAssociacao(associacao)">edit</mat-icon>
+                        </button>
+                    </td>
+                </ng-container>
+
+                <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                <tr mat-row *matRowDef="let associacao; columns: displayedColumns;"></tr>
+
+                <!-- Row shown when there is no matching data. -->
+                <tr class="mat-row" *matNoDataRow>
+                    <td class="mat-cell" colspan="4">Nenhuma associação cadastrada com a informação filtrada "{{input.value}}"</td>
+                </tr>
+            </table>
+            <mat-paginator [pageSizeOptions]="[5, 10, 25]"></mat-paginator>            
+        </div> 
+        <mat-divider></mat-divider>       
+    </div>
+</div>

--- a/src/app/paginas/listar-associacao/listar-associacao.component.scss
+++ b/src/app/paginas/listar-associacao/listar-associacao.component.scss
@@ -1,0 +1,88 @@
+@import "../../_shared/styles/colors";
+
+.container {
+  width: 100%;
+  min-height: 75vh;
+  height: max-content;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  background-color: $c-background;
+}
+
+.box {
+  width: 95%;
+  height: 90%;
+  min-height: 70vh;
+  background: $c-white;
+  flex-direction: column;
+  display: flex;
+  align-items: center;
+}
+
+.box2 {
+  width: 95%;
+  height: 90%;
+  background: $c-white;
+  flex-direction: row;
+  display: flex;
+  align-items: center;
+  margin-top: 15px;
+}
+
+.box3 {
+  width: 95%;
+  height: 90%;
+  background: $c-white;
+  flex-direction: column;
+  display: flex;
+  align-items: center;
+  margin-top: 15px;
+}
+
+h1 {
+  color: $c-primary;
+  font-size: 36px;
+  align-self: flex-start;
+}
+
+table {
+  width: 90%;
+  margin: 0 auto;
+}
+.mat-form-field {
+  font-size: 14px;
+  width: 100%;
+}
+
+.mat-elevation-z8 {
+  width: 95%;
+  margin-bottom: 25px;
+}
+
+td,
+th {
+  width: 25%;
+}
+
+th.mat-header-cell:last-child {
+  text-align: center;
+}
+
+mat-icon {
+  color: $c-secondary;
+}
+
+button.mat-raised-button {
+  background-color: $c-white;
+  color: $c-primary;
+  width: 150px;
+  margin-right: 15px;
+}
+
+button.mat-raised-button:hover{
+  background-color: $c-primary;
+  color: $c-secondary;
+  width: 150px;
+  margin-right: 15px;
+}

--- a/src/app/paginas/listar-associacao/listar-associacao.component.spec.ts
+++ b/src/app/paginas/listar-associacao/listar-associacao.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ListarAssociacaoComponent } from './listar-associacao.component';
+
+describe('ListarAssociacaoComponent', () => {
+  let component: ListarAssociacaoComponent;
+  let fixture: ComponentFixture<ListarAssociacaoComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ListarAssociacaoComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ListarAssociacaoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/paginas/listar-associacao/listar-associacao.component.ts
+++ b/src/app/paginas/listar-associacao/listar-associacao.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnInit, AfterViewInit, ViewChild } from '@angular/core';
+import { AssociacaoService } from '../../_services/associacao.service';
+import { Associacao } from '../../_models/associacao';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import { Router } from '@angular/router'
+
+@Component({
+  selector: 'app-listar-associacao',
+  templateUrl: './listar-associacao.component.html',
+  styleUrls: ['./listar-associacao.component.scss']
+})
+export class ListarAssociacaoComponent implements OnInit {
+
+  associacao: Array<Associacao> = [];
+  displayedColumns: string[] = ['sigla', 'nome', 'cnpj', 'cidade', 'uf', 'acoes'];
+  dataSource: MatTableDataSource<Associacao[]>;
+
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatSort) sort: MatSort;
+
+  constructor(
+    private associacaoService: AssociacaoService,
+    private router: Router) {
+    this.loadData();
+  }
+  private loadData(): void {
+    this.associacaoService.listarAssociacao().subscribe((res) => {
+      this.dataSource = new MatTableDataSource(res);
+      this.dataSource.paginator = this.paginator;
+    });
+  }
+  ngOnInit(): void {
+    this.associacaoService.zerarAssociacao();
+  }
+
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
+  }
+
+  goToPage(pageName: string) {
+    this.router.navigate([`${pageName}`]);
+  }
+
+  editarAssociacao(associacao: Associacao){
+    this.associacaoService.associacao = associacao;  
+    this.goToPage('associacao/cadastro');
+  }
+}


### PR DESCRIPTION
- Cria página para listagem da Associação, com paginação, opção de editar a associação, incluir uma associação nova, e um campo para filtro.    (PS: utilizando o mesmo formulário e endpoint para o cadastro da associação)
- Ajustes no comprovante de cadastro da associação, inclusão de um botão para redirecionar para a listagem de associações e também foi colocado as informações do cadastro ou alteração realizada.
- Feito também os ajustes sugeridos pelo Carlos na feat/0002