### PR TITLE
Configura comunicação do Front com a API para cadastro de Associação

### DIFF
--- a/src/app/_models/associacao.ts
+++ b/src/app/_models/associacao.ts
@@ -1,9 +1,11 @@
+import { Endereco } from "./endereco";
+import { Usuario } from "./usuario";
+
 export class Associacao {
-    id?: string;
+    codigo?: number;
     cnpj: string;
     sigla: string;
     nome: string;
-    cidade: string;
-    uf: string;
-    dataCadastro: string;
+    enderecoHttp: Endereco = new Endereco();
+    usuarioHttp: Usuario = new Usuario();
 }

--- a/src/app/_models/criador.ts
+++ b/src/app/_models/criador.ts
@@ -1,16 +1,17 @@
 import { Endereco } from './endereco'
-import { Ave } from './ave'
+import { Associacao } from './associacao';
+import { Usuario } from './usuario'
 
 export class Criador {
-    cpf: string;
-    rg: string;
-    ibama: string;
+    codigo?: number;
     nome: string;
     sobrenome: string;
     telefone: string;
-    email: string;
-    data_cadastro: string;
-    senha: string;
-    endereco?: Endereco;
-    ave?: Ave[];
+    cpf: string;
+    rg: string;
+    ctf: string;
+    ativo: boolean;
+    AssociacaoHttp: Associacao;
+    enderecoHttp: Endereco;
+    usuarioHttp: Usuario;
 }

--- a/src/app/_models/endereco.ts
+++ b/src/app/_models/endereco.ts
@@ -1,10 +1,9 @@
 export class Endereco {
-    id?: string;
-    logradouro?: string;
-    numero?: string;
-    bairro?: string;
-    complemento?: string;
-    cep?: string;
-    cidade?: string;
-    uf?: string;
+    logradouro: string;
+    numero: string;
+    complemento: string;
+    bairro: string;
+    cidade: string;
+    estado: string;
+    cep: string;
 }

--- a/src/app/_models/usuario.ts
+++ b/src/app/_models/usuario.ts
@@ -1,0 +1,11 @@
+import { Associacao } from "./associacao";
+import { Criador } from "./criador";
+
+export class Usuario {
+    codigo?: number;
+    email: string;
+    senha: string;
+    tipo: string;
+    criadorHttp: Criador;
+    associacaoHttp: Associacao;
+}

--- a/src/app/_services/associacao.service.ts
+++ b/src/app/_services/associacao.service.ts
@@ -19,15 +19,19 @@ export class AssociacaoService {
   }
 
   postAssociacao(associacao: Associacao) {
-    return this.httpClient.post<Associacao>('http://localhost:8080/associacao', associacao);
+    return this.httpClient.post<Associacao>('http://localhost:8080/api/associacao', associacao);
   }
 
   getAssociacaoPorCnpj(cnpj: string): Observable<any> {
-    return this.httpClient.get<any>('http://localhost:8080/associacao/cnpj/' + cnpj);
+    return this.httpClient.get<any>('http://localhost:8080/api/associacao/cnpj/' + cnpj);
   }
 
   listarAssociacao(): Observable<any>{
-    return this.httpClient.get<Associacao[]>('http://localhost:8080/associacao');
+    return this.httpClient.get<Associacao[]>('http://localhost:8080/api/associacao');
+  }
+
+  putAssociacao(associacao: Associacao): Observable<any> {
+    return this.httpClient.put<Associacao>('http://localhost:8080/api/associacao/' + associacao.codigo, associacao);
   }
 
   zerarAssociacao(){

--- a/src/app/paginas/cadastrar-associacao/cadastrar-associacao.component.html
+++ b/src/app/paginas/cadastrar-associacao/cadastrar-associacao.component.html
@@ -5,6 +5,8 @@
 
             <form [formGroup]="formCadastro" (ngSubmit)="onSubmit()">
 
+                <mat-divider></mat-divider>
+                <h3>Dados de identificação</h3>
                 <div class="box3">
                     <div class="box4">
                         <label>Nome</label>
@@ -55,21 +57,40 @@
                         </p>
                     </div>
                     <div class="box4">
+                        <label>E-mail</label>
+                        <p>
+                            <mat-form-field appearance="outline">
+                                <mat-label>E-mail</mat-label>
+                                <input matInput formControlName="emailUsuarioFormControl" minlength="3" maxlength="100"
+                                    required>
+                                <mat-error *ngIf="formCadastro.controls.emailUsuarioFormControl.errors?.required">Campo
+                                    obrigatório</mat-error>
+                                <mat-error *ngIf="formCadastro.controls.emailUsuarioFormControl.errors?.email">Este
+                                    e-mail não
+                                    é válido</mat-error>
+                            </mat-form-field>
+                        </p>
+                    </div>
+
+                </div>
+
+                <mat-divider></mat-divider>
+                <h3>Endereço</h3>
+                <div class="box3">
+                    <div class="box4">
                         <label>Cidade</label>
                         <p>
                             <mat-form-field appearance="outline">
                                 <mat-label>Cidade</mat-label>
-                                <input matInput formControlName="cidadeFormControl" minlength="3" maxlength="100"
+                                <input matInput formControlName="cidadeFormControl" minlength="2" maxlength="100"
                                     required>
                                 <mat-error *ngIf="formCadastro.controls.cidadeFormControl.errors?.required">Campo
                                     obrigatório</mat-error>
                                 <mat-error *ngIf="formCadastro.controls.cidadeFormControl.errors?.minlength">Tem que
-                                    ter no mínimo 9 caracteres</mat-error>
+                                    ter no mínimo 2 caracteres</mat-error>
                             </mat-form-field>
                         </p>
                     </div>
-                </div>
-                <div class="box3">
                     <div class="box4">
                         <label>Selecione o estado do seu clube</label>
                         <p>
@@ -85,7 +106,128 @@
                             </mat-form-field>
                         </p>
                     </div>
+                </div>
+                <div class="box3">
                     <div class="box4">
+                        <label>Logradouro</label>
+                        <p>
+                            <mat-form-field appearance="outline">
+                                <mat-label>Logradouro</mat-label>
+                                <input matInput formControlName="logradouroFormControl" minlength="2" maxlength="100"
+                                    required>
+                                <mat-error *ngIf="formCadastro.controls.logradouroFormControl.errors?.required">Campo
+                                    obrigatório</mat-error>
+                                <mat-error *ngIf="formCadastro.controls.logradouroFormControl.errors?.minlength">Tem que
+                                    ter no mínimo 9 caracteres</mat-error>
+                            </mat-form-field>
+                        </p>
+                    </div>
+                    <div class="box4">
+                        <label>Número</label>
+                        <p>
+                            <mat-form-field appearance="outline">
+                                <mat-label>Número</mat-label>
+                                <input matInput formControlName="numeroFormControl" minlength="1" maxlength="100"
+                                    required>
+                                <mat-error *ngIf="formCadastro.controls.numeroFormControl.errors?.required">Campo
+                                    obrigatório</mat-error>
+                                <mat-error *ngIf="formCadastro.controls.numeroFormControl.errors?.minlength">Tem que
+                                    ter no mínimo 1 caracter</mat-error>
+                            </mat-form-field>
+                        </p>
+                    </div>
+                </div>
+                <div class="box3">
+                    <div class="box4">
+                        <label>Bairro</label>
+                        <p>
+                            <mat-form-field appearance="outline">
+                                <mat-label>Bairro</mat-label>
+                                <input matInput formControlName="bairroFormControl" minlength="2" maxlength="100"
+                                    required>
+                                <mat-error *ngIf="formCadastro.controls.bairroFormControl.errors?.required">Campo
+                                    obrigatório</mat-error>
+                                <mat-error *ngIf="formCadastro.controls.bairroFormControl.errors?.minlength">Tem que
+                                    ter no mínimo  caracteres</mat-error>
+                            </mat-form-field>
+                        </p>
+                    </div>
+                    <div class="box4">
+                        <label>Complemento</label>
+                        <p>
+                            <mat-form-field appearance="outline">
+                                <mat-label>Complemento</mat-label>
+                                <input matInput formControlName="complementoFormControl" minlength="1" maxlength="100"
+                                    required>
+                                <mat-error *ngIf="formCadastro.controls.complementoFormControl.errors?.required">Campo
+                                    obrigatório</mat-error>
+                                <mat-error *ngIf="formCadastro.controls.complementoFormControl.errors?.minlength">Tem que
+                                    ter no mínimo 1 caracter</mat-error>
+                            </mat-form-field>
+                        </p>
+                    </div>
+                </div>
+                <div class="box3">
+                    <div class="box4">
+                        <label>CEP</label>
+                        <p>
+                            <mat-form-field appearance="outline">
+                                <mat-label>CEP</mat-label>
+                                <input matInput formControlName="cepFormControl" minlength="3" maxlength="100"
+                                    required>
+                                <mat-error *ngIf="formCadastro.controls.cepFormControl.errors?.required">Campo
+                                    obrigatório</mat-error>
+                                <mat-error *ngIf="formCadastro.controls.cepFormControl.errors?.minlength">Tem que
+                                    ter no mínimo 9 caracteres</mat-error>
+                            </mat-form-field>
+                        </p>
+                    </div>
+                    <div class="box4">                        
+                    </div>
+                </div>
+
+                <mat-divider></mat-divider>
+                <h3 *ngIf="formCadastro.controls.idFormControl.value === null" >Senhas</h3>
+                <div *ngIf="formCadastro.controls.idFormControl.value === null"  class="box3">
+                    <div class="box4">
+                        <label>Senha</label>
+                        <p>
+                            <mat-form-field appearance="outline">
+                                <mat-label>Senha</mat-label>
+                                <input matInput [type]="hide ? 'password' : 'text'"
+                                    formControlName="senhaUsuarioFormControl" required>
+                                <mat-error></mat-error>
+                                <button mat-icon-button matSuffix type="button" (click)="hide = !hide"
+                                    [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
+                                    <mat-icon>{{hide ? 'visibility_off' : 'visibility'}}</mat-icon>
+                                </button>
+                                <mat-error *ngIf="formCadastro.controls.senhaUsuarioFormControl.errors?.required">Campo
+                                    obrigatório</mat-error>
+                            </mat-form-field>
+                        </p>
+                    </div>
+                    <div class="box4">
+                        <div class="box3">
+                            <label>Confirmar senha</label>
+                        </div>
+                        <p>
+                            <mat-form-field appearance="outline">
+                                <mat-label>Confirnar senha</mat-label>
+                                <input matInput [type]="hide ? 'password' : 'text'"
+                                    formControlName="confirmarSenhaUsuarioFormControl" required>
+                                <button mat-icon-button matSuffix type="button" (click)="hide = !hide"
+                                    [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
+                                    <mat-icon>{{hide ? 'visibility_off' : 'visibility'}}</mat-icon>
+                                </button>
+                                <mat-error
+                                    *ngIf="formCadastro.controls.confirmarSenhaUsuarioFormControl.errors?.required">
+                                    Campo
+                                    obrigatório</mat-error>
+                                <mat-error
+                                    *ngIf="formCadastro.controls.confirmarSenhaUsuarioFormControl.errors?.identityRevealed">
+                                    As senhas informadas devem ser iguais</mat-error>
+                            </mat-form-field>
+                        </p>
                     </div>
                 </div>
 

--- a/src/app/paginas/cadastrar-associacao/cadastrar-associacao.component.ts
+++ b/src/app/paginas/cadastrar-associacao/cadastrar-associacao.component.ts
@@ -17,62 +17,91 @@ export class CadastrarAssociacaoComponent implements OnInit {
 
 
   constructor(private router: Router, private associacaoService: AssociacaoService, private _snackBar: MatSnackBar,) { }
-
+  hide = true;
   associacao: Associacao = new Associacao();
   consultaCnpj: string = '';
 
   identityRevealedValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
-    const cnpj = control.get('cnpjFormControl');
+    const senha = control.get('senhaUsuarioFormControl');
+    const confirmarSenha = control.get('confirmarSenhaUsuarioFormControl');
 
-    if (cnpj.value) {
-      cnpj.setErrors({ identityRevealed: true });
+    if (senha.value !== confirmarSenha.value) {
+      confirmarSenha.setErrors({ identityRevealed: true });
       return { identityRevealed: true };
     }
-    cnpj.setErrors(null);
+    confirmarSenha.setErrors(null);
     return null;
   };
 
-  forbiddenNameValidator(nameRe: Associacao): ValidatorFn {
-    return (control: AbstractControl): { [key: string]: any } | null => {
-      const forbidden = nameRe;
-      return forbidden.cnpj === control.value ? { forbiddenName: { value: control.value } } : null;
-    };
-  }
-
   formCadastro = new FormGroup({
+    idFormControl: new FormControl(this.associacaoService.associacao.codigo ? this.associacaoService.associacao.codigo : null),
     cnpjFormControl: new FormControl(this.associacaoService.associacao.cnpj ? this.associacaoService.associacao.cnpj : ''),
     siglaFormControl: new FormControl(this.associacaoService.associacao.sigla ? this.associacaoService.associacao.sigla : ''),
     nomeFormControl: new FormControl(this.associacaoService.associacao.nome ? this.associacaoService.associacao.nome : ''),
-    cidadeFormControl: new FormControl(this.associacaoService.associacao.cidade ? this.associacaoService.associacao.cidade : ''),
-    ufFormControl: new FormControl(this.associacaoService.associacao.uf ? this.associacaoService.associacao.uf : ''),
-    idFormControl: new FormControl(this.associacaoService.associacao.id ? this.associacaoService.associacao.id : '')
-  });
+    cidadeFormControl: new FormControl(this.associacaoService.associacao.enderecoHttp.cidade ? this.associacaoService.associacao.enderecoHttp.cidade : ''),
+    ufFormControl: new FormControl(this.associacaoService.associacao.enderecoHttp.estado ? this.associacaoService.associacao.enderecoHttp.estado : ''),
+    logradouroFormControl: new FormControl(this.associacaoService.associacao.enderecoHttp.logradouro ? this.associacaoService.associacao.enderecoHttp.logradouro : ''),
+    numeroFormControl: new FormControl(this.associacaoService.associacao.enderecoHttp.numero ? this.associacaoService.associacao.enderecoHttp.numero : ''),
+    complementoFormControl: new FormControl(this.associacaoService.associacao.enderecoHttp.complemento ? this.associacaoService.associacao.enderecoHttp.complemento : ''),
+    bairroFormControl: new FormControl(this.associacaoService.associacao.enderecoHttp.bairro ? this.associacaoService.associacao.enderecoHttp.bairro : ''),
+    cepFormControl: new FormControl(this.associacaoService.associacao.enderecoHttp.cep ? this.associacaoService.associacao.enderecoHttp.cep : ''),
+    codigoUsuarioFormControl: new FormControl(this.associacaoService.associacao.usuarioHttp.codigo ? this.associacaoService.associacao.usuarioHttp.codigo : ''),
+    emailUsuarioFormControl: new FormControl(this.associacaoService.associacao.usuarioHttp.email ? this.associacaoService.associacao.usuarioHttp.email : '', [Validators.email]),
+    senhaUsuarioFormControl: new FormControl(this.associacaoService.associacao.usuarioHttp.senha ? this.associacaoService.associacao.usuarioHttp.senha : ''),
+    confirmarSenhaUsuarioFormControl: new FormControl(''),
+    tipoUsuarioFormControl: new FormControl('TPUS01')
+  }, { validators: this.identityRevealedValidator });
 
   ngOnInit(): void {
-    
+
   }
 
   onSubmit() {
     const {
+      idFormControl,
       cnpjFormControl,
-      nomeFormControl,
       siglaFormControl,
+      nomeFormControl,
       cidadeFormControl,
       ufFormControl,
-      idFormControl
-    } = this.formCadastro.controls
+      logradouroFormControl,
+      numeroFormControl,
+      complementoFormControl,
+      bairroFormControl,
+      cepFormControl,
+      codigoUsuarioFormControl,
+      emailUsuarioFormControl,
+      senhaUsuarioFormControl,
+      confirmarSenhaUsuarioFormControl,
+      tipoUsuarioFormControl
 
+    } = this.formCadastro.controls
+    this.associacao.codigo = idFormControl.value;
     this.associacao.cnpj = cnpjFormControl.value;
     this.associacao.nome = nomeFormControl.value;
     this.associacao.sigla = siglaFormControl.value;
-    this.associacao.cidade = cidadeFormControl.value;
-    this.associacao.uf = ufFormControl.value;
-    this.associacao.id = idFormControl.value;
+    this.associacao.enderecoHttp.cidade = cidadeFormControl.value;
+    this.associacao.enderecoHttp.estado = ufFormControl.value;
+    this.associacao.enderecoHttp.logradouro = logradouroFormControl.value;
+    this.associacao.enderecoHttp.numero = numeroFormControl.value;
+    this.associacao.enderecoHttp.complemento = complementoFormControl.value;
+    this.associacao.enderecoHttp.bairro = bairroFormControl.value;
+    this.associacao.enderecoHttp.cep = cepFormControl.value;
+    this.associacao.usuarioHttp.codigo = codigoUsuarioFormControl.value;
+    this.associacao.usuarioHttp.email = emailUsuarioFormControl.value;
+    this.associacao.usuarioHttp.senha = senhaUsuarioFormControl.value;
+    this.associacao.usuarioHttp.tipo = tipoUsuarioFormControl.value;
 
     if (this.consultaCnpj === this.associacao.cnpj) {
-      this.openSnackBar('Este CNPJ já está sendo usando', 'OK');
-    } else {
+      this.openSnackBar('Este CNPJ já está sendo usado', 'OK');
+    } else if (this.associacao.codigo === null) {
       this.associacaoService.postAssociacao(this.associacao).subscribe((res) => {
+        this.associacaoService.associacao = res;
+        this.goToPage('associacao/comprovante-cadastro');
+      })
+    } else {
+      console.log(this.associacao)
+      this.associacaoService.putAssociacao(this.associacao).subscribe((res) => {
         this.associacaoService.associacao = res;
         this.goToPage('associacao/comprovante-cadastro');
       })
@@ -82,7 +111,7 @@ export class CadastrarAssociacaoComponent implements OnInit {
   consultarCnpj(cnpj: string) {
     this.associacaoService.getAssociacaoPorCnpj(cnpj).subscribe(
       (res) => {
-        if(res.cnpj === cnpj){
+        if (res.cnpj === cnpj) {
           this.consultaCnpj = res.cnpj;
           this.openSnackBar('Este CNPJ já está sendo usando', 'OK');
         }

--- a/src/app/paginas/cadastrar-criador/cadastrar-criador.component.ts
+++ b/src/app/paginas/cadastrar-criador/cadastrar-criador.component.ts
@@ -118,29 +118,20 @@ export class CadastrarCriadorComponent implements OnInit {
     this.endereco.cidade = cidadeFormControl.value;
     this.endereco.logradouro = ruaFormControl.value;
     this.endereco.numero = numeroFormControl.value;
-    this.endereco.uf = ufEnderecoFormControl.value;
+    this.endereco.estado = ufEnderecoFormControl.value;
 
     this.criador.nome = nomeFormControl.value;
     this.criador.sobrenome = sobrenomeFormControl.value;
-    this.criador.senha = senhaFormControl.value;
-    this.criador.ibama = ctfFormControl.value;
+    this.criador.usuarioHttp.senha = senhaFormControl.value;
+    this.criador.ctf = ctfFormControl.value;
     this.criador.rg = rgFormControl.value;
     this.criador.telefone = celularFormControl.value;
     this.criador.cpf = cpfFormControl.value;
-    this.criador.email = emailFormControl.value;
+    this.criador.usuarioHttp.email = emailFormControl.value;
 
-    this.enderecoService.postEndereco(this.endereco).subscribe((res) => {
-
-      this.criador.endereco = new Endereco();
-      this.enderecoService.endereco = res;
-      this.criador.endereco.id = res.id;
-
-      this.criadorService.postCriador(this.criador).subscribe((res) => {
-
-        this.criadorService.criador = res;
-        this.goToPage('criador/comprovante-cadastro');
-      });
-
+    this.criadorService.postCriador(this.criador).subscribe((res) => {
+      this.criadorService.criador = res;
+      this.goToPage('criador/comprovante-cadastro');
     });
   }
 
@@ -152,11 +143,7 @@ export class CadastrarCriadorComponent implements OnInit {
     this._snackBar.open(message, action, {
       duration: 8000,
     });
-  }
-
-  isValid() {
-    return this.formCadastro.invalid || this.formCadastro.controls.senhaFormControl.value !== this.formCadastro.controls.confirmarSenhaFormControl.value
-  }
+  } 
 
   openDialog() {
     this.dialog.open(TermoDeResponsabilidadeComponent);

--- a/src/app/paginas/comprovante-cadastro-associacao/comprovante-cadastro-associacao.component.html
+++ b/src/app/paginas/comprovante-cadastro-associacao/comprovante-cadastro-associacao.component.html
@@ -3,13 +3,13 @@
         <div class="box2">
             <h3>Cadastro efetuado com sucesso!!!</h3>
 
-            <p>Código: <strong>{{this.associacao.id}}</strong></p>
+            <p>Código: <strong>{{this.associacao.codigo}}</strong></p>
             <p>Nome: <strong>{{this.associacao.nome}}</strong></p>
             <p>Sigla: <strong>{{this.associacao.sigla}}</strong></p>
             <p>CNPJ: <strong>{{this.associacao.cnpj}}</strong></p>
-            <p>Cidade: <strong>{{this.associacao.cidade}}</strong></p>
-            <p>UF: <strong>{{this.associacao.uf}}</strong></p>
-            <p>Data e hora: <strong>{{this.associacao.dataCadastro}}</strong></p>
+            <p>Cidade: <strong>{{this.associacao.enderecoHttp.cidade}}</strong></p>
+            <p>UF: <strong>{{this.associacao.enderecoHttp.estado}}</strong></p>
+            <p>E-mail: <strong>{{this.associacao.usuarioHttp.email}}</strong></p>
 
             <div class="box3">
                 <button mat-raised-button (click)="goToPage('home')" class="botaoPaginaInicial">Página Inicial</button>

--- a/src/app/paginas/listar-associacao/listar-associacao.component.html
+++ b/src/app/paginas/listar-associacao/listar-associacao.component.html
@@ -36,12 +36,12 @@
                 <!-- Color Column -->
                 <ng-container matColumnDef="cidade">
                     <th mat-header-cell *matHeaderCellDef mat-sort-header> Cidade </th>
-                    <td mat-cell *matCellDef="let associacao"> {{associacao.cidade}} </td>
+                    <td mat-cell *matCellDef="let associacao"> {{associacao.enderecoHttp.cidade}} </td>
                 </ng-container>
 
                 <ng-container matColumnDef="uf">
                     <th mat-header-cell *matHeaderCellDef mat-sort-header> UF </th>
-                    <td mat-cell *matCellDef="let associacao"> {{associacao.uf}} </td>
+                    <td mat-cell *matCellDef="let associacao"> {{associacao.enderecoHttp.estado}} </td>
                 </ng-container>
 
                 <ng-container matColumnDef="acoes">


### PR DESCRIPTION
- Configura comunicação do Front com a API para cadastro de Associação
- Ajuste de atributos e objetos
- Ajuste na service de associação
- Ajuste na pagina de cadastro de criador por causa de mudanças de nomes de atributos (PS: essa página ainda não está comunicando com a nova API)